### PR TITLE
Fixes markdown path in bloggen_test.go

### DIFF
--- a/bloggen_test.go
+++ b/bloggen_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNewBlogSite(t *testing.T) {
-	markdownFS := os.DirFS("cmd/markdown")
+	markdownFS := os.DirFS("cmd/bloggen/markdown")
 	blogDirectory := "testbuild"
 	bloggen.NewBlogSite(markdownFS, blogDirectory)
 


### PR DESCRIPTION
This pull request resolves #5 by changing the `markdown` path from `cmd/markdown` to `cmd/bloggen/markdown`